### PR TITLE
Format option

### DIFF
--- a/Console/Command/DotcakeShell.php
+++ b/Console/Command/DotcakeShell.php
@@ -1,6 +1,7 @@
 <?php
 App::uses('Shell', 'Console');
 App::uses('Dotcake', 'Dotcake.Lib');
+App::uses('Formatter', 'Dotcake.Lib');
 
 /**
  * DotcakeShell class
@@ -51,7 +52,38 @@ class DotcakeShell extends Shell {
 	public function generate() {
 		$this->out('Generate .cake ...');
 		$d = new Dotcake(APP, App::paths(), CAKE_CORE_INCLUDE_PATH);
-		$this->createFile(APP . '.cake', json_encode($d->generate()));
+		$contents = json_encode($d->generate());
+		if (array_key_exists('format', $this->params)) {
+			$format = $this->params['format'];
+			switch ($format) {
+				case 'tab':
+					$formatter = new Formatter();
+					$contents = $formatter->reformat($contents);
+					break;
+				case 'ws': // no break
+				case 'whitespace':
+					// can use JSON_PRETTY_PRINT option since PHP5.4
+					$formatter = new Formatter('    '); // 4 spaces
+					$contents = $formatter->reformat($contents);
+					break;
+				default:
+					$this->out(__d('cake_console', "'{$format}' is invalid format option. You can use 'tab', 'ws' or 'whitespace' as option value."));
+					exit(0);
+			}
+		}
+		$this->createFile(APP . '.cake', $contents);
+	}
+
+/**
+ * getOptionParser
+ *
+ */
+	public function getOptionParser() {
+		$parser = parent::getOptionParser();
+		$parser->addOption('format', array(
+			'help' => __d('cake_console', "Generate formatted json with tab or whitespace:'tab', 'ws' or 'whitespace'"),
+		));
+		return $parser;
 	}
 
 /**

--- a/Lib/Formatter.php
+++ b/Lib/Formatter.php
@@ -1,0 +1,99 @@
+<?php
+
+/**
+ * Formatter class
+ *
+ * @copyright     Copyright (c) dotcake organization. (https://github.com/dotcake)
+ * @license       http://www.opensource.org/licenses/mit-license.php MIT License
+ */
+class Formatter {
+
+	private $__indentString;
+
+	private $__indentCount = 0;
+
+	private $__isInQuotes = false;
+
+	public function __construct($indentString = "\t") {
+		$this->__indentString = $indentString;
+	}
+
+/**
+ * Reformat
+ *
+ * @param string $text
+ */
+	public function reformat($text) {
+		$formattedText = "";
+		$strlen = strlen($text);
+		for ($i = 0; $i < $strlen; $i++) {
+			// only single byte
+			$char = $text[$i];
+			switch ($char) {
+				case '{': // no break
+				case '[':
+					$this->__increaseIndentCount();
+					$formattedText .= $char . $this->__getNewLine() . $this->__getIndent();
+					break;
+				case '}': // no break
+				case ']':
+					$this->__decreaseIndentCount();
+					$formattedText .= $this->__getNewLine() . $this->__getIndent() . $char;
+					break;
+				case ',':
+					$formattedText .= $char . $this->__getNewLine() . $this->__getIndent();
+					break;
+				case '"':
+					$this->__isInQuotes = !$this->__isInQuotes;
+					$formattedText .= $char;
+					break;
+				case '\\':
+					$formattedText .= $char . $text[++$i];
+					break;
+				default:
+					$formattedText .= $char;
+					break;
+			}
+		}
+		return $formattedText;
+	}
+
+/**
+ * Get new line
+ *
+ * @return string New line if it's not in quotes, otherwise empty string.
+ */
+	private function __getNewLine() {
+		return $this->__isInQuotes ? "" : "\n";
+	}
+
+/**
+ * Get indent
+ *
+ * @return string Empty string if indent count is 0 or it's in quotes, otherwise indent space.
+ */
+	private function __getIndent() {
+		return $this->__isInQuotes ? "" : str_repeat($this->__indentString, $this->__indentCount);
+	}
+
+/**
+ * Increase indent count
+ *
+ */
+	private function __increaseIndentCount() {
+		if (!$this->__isInQuotes) {
+			$this->__indentCount++;
+		}
+	}
+
+/**
+ * Decrease indent count
+ *
+ */
+	private function __decreaseIndentCount() {
+		if (!$this->__isInQuotes) {
+			$this->__indentCount--;
+		}
+	}
+
+}

--- a/Lib/Formatter.php
+++ b/Lib/Formatter.php
@@ -19,7 +19,9 @@ class Formatter {
 	}
 
 /**
- * Reformat
+ * Reformat return value of json_encode().
+ * Note: If a text contains whitespace, tab, e.t.c.,
+ * this method will return broken format.
  *
  * @param string $text
  */

--- a/README.md
+++ b/README.md
@@ -17,3 +17,7 @@ This plugin is
 ## Generate .cake
 
 $ cake Dotcake.dotcake generate
+
+### Options
+
+- `--format` [tab|ws|whitespace]: Return formatted json with tab or whitespace (4 spaces). 

--- a/Test/Case/Lib/FormatterTest.php
+++ b/Test/Case/Lib/FormatterTest.php
@@ -32,7 +32,7 @@ class FormatterTestCase extends CakeTestCase {
 	public function testReformat() {
 		$this->Formatter = new Formatter();
 		$text = <<< EOD
-{"cake":"..\/lib\/","build_path":{"models":[".\/Model\/"],"behaviors":[".\/Model\/Behavior\/"]}}
+{"cake":"..\/lib\/","build_path":{"models":[".\/Model\/"],"behaviors":[".\/Model\/Behavior\/",".\/MyModel\/Behavior\/"]}}
 EOD;
 		$result = $this->Formatter->reformat($text);
 		$expected = <<< EOD
@@ -43,7 +43,8 @@ EOD;
 			".\/Model\/"
 		],
 		"behaviors":[
-			".\/Model\/Behavior\/"
+			".\/Model\/Behavior\/",
+			".\/MyModel\/Behavior\/"
 		]
 	}
 }
@@ -58,7 +59,7 @@ EOD;
 	public function testReformatWithWhitespace() {
 		$this->Formatter = new Formatter("    ");
 		$text = <<< EOD
-{"cake":"..\/lib\/","build_path":{"models":[".\/Model\/"],"behaviors":[".\/Model\/Behavior\/"]}}
+{"cake":"..\/lib\/","build_path":{"models":[".\/Model\/"],"behaviors":[".\/Model\/Behavior\/",".\/MyModel\/Behavior\/"]}}
 EOD;
 		$result = $this->Formatter->reformat($text);
 		$expected = <<< EOD
@@ -69,7 +70,8 @@ EOD;
             ".\/Model\/"
         ],
         "behaviors":[
-            ".\/Model\/Behavior\/"
+            ".\/Model\/Behavior\/",
+            ".\/MyModel\/Behavior\/"
         ]
     }
 }

--- a/Test/Case/Lib/FormatterTest.php
+++ b/Test/Case/Lib/FormatterTest.php
@@ -1,0 +1,103 @@
+<?php
+
+App::uses('Formatter', 'Dotcake.Lib');
+
+/**
+ * FormatterTestCase file
+ *
+ * @copyright     Copyright (c) dotcake organization. (https://github.com/dotcake)
+ * @license       http://www.opensource.org/licenses/mit-license.php MIT License
+ */
+class FormatterTestCase extends CakeTestCase {
+
+/**
+ * setUp
+ *
+ */
+	public function setUp() {
+	}
+
+/**
+ * tearDown
+ *
+ */
+	public function tearDown() {
+		unset($this->Formatter);
+	}
+
+/**
+ * testReformat
+ *
+ */
+	public function testReformat() {
+		$this->Formatter = new Formatter();
+		$text = <<< EOD
+{"cake":"..\/lib\/","build_path":{"models":[".\/Model\/"],"behaviors":[".\/Model\/Behavior\/"]}}
+EOD;
+		$result = $this->Formatter->reformat($text);
+		$expected = <<< EOD
+{
+	"cake":"..\/lib\/",
+	"build_path":{
+		"models":[
+			".\/Model\/"
+		],
+		"behaviors":[
+			".\/Model\/Behavior\/"
+		]
+	}
+}
+EOD;
+		$this->assertEquals($expected, $result);
+	}
+
+/**
+ * testReformatWithWhitespace
+ *
+ */
+	public function testReformatWithWhitespace() {
+		$this->Formatter = new Formatter("    ");
+		$text = <<< EOD
+{"cake":"..\/lib\/","build_path":{"models":[".\/Model\/"],"behaviors":[".\/Model\/Behavior\/"]}}
+EOD;
+		$result = $this->Formatter->reformat($text);
+		$expected = <<< EOD
+{
+    "cake":"..\/lib\/",
+    "build_path":{
+        "models":[
+            ".\/Model\/"
+        ],
+        "behaviors":[
+            ".\/Model\/Behavior\/"
+        ]
+    }
+}
+EOD;
+		$this->assertEquals($expected, $result);
+	}
+
+/**
+ * testReformatQuotedBracesAndComma
+ *
+ */
+	public function testReformatQuotedBracesAndComma() {
+		$this->Formatter = new Formatter();
+		$text = <<< EOD
+{"cake":"}","build_path":{"models":[",["]}}
+EOD;
+		$result = $this->Formatter->reformat($text);
+		$expected = <<< EOD
+{
+	"cake":"}",
+	"build_path":{
+		"models":[
+			",["
+		]
+	}
+}
+EOD;
+		$this->assertEquals($expected, $result);
+	}
+
+}


### PR DESCRIPTION
フォーマットして出力するオプションを追加しました。

```
$ cake Dotcake.dotcake generate --format tab
$ cake Dotcake.dotcake generate --format ws
```
#### Note

`Formatter::reformat()`は空白等がある場合は考慮していません。もし既にフォーマットされているものを再フォーマットするときに使用する場合は修正が必要です。
