### PR TITLE
Add "cake_version" value.

### DIFF
--- a/Lib/Dotcake.php
+++ b/Lib/Dotcake.php
@@ -46,6 +46,7 @@ class Dotcake {
  */
 	public function generate() {
 		$dotcake = array();
+		$dotcake['cake_version'] = Configure::version();
 		$dotcake['cake'] = $this->__cake;
 		$dotcake['build_path'] = array();
 		$paths = $this->__paths;

--- a/Test/Case/Lib/DotcakeTest.php
+++ b/Test/Case/Lib/DotcakeTest.php
@@ -27,7 +27,7 @@ class DotcakeTestCase extends CakeTestCase {
 	}
 
 /**
- * test_simpleGenerate
+ * testSimpleGenerate
  *
  */
 	public function testSimpleGenerate() {
@@ -35,6 +35,7 @@ class DotcakeTestCase extends CakeTestCase {
 		$result = $this->Dotcake->generate();
 		$this->assertTrue(array_key_exists('cake', $result));
 		$this->assertTrue(array_key_exists('build_path', $result));
+		$this->assertTrue(array_key_exists('cake_version', $result));
 		$this->assertEqual(realpath(APP . $result['cake']), realpath(CAKE_CORE_INCLUDE_PATH));
 		$this->assertEqual(count($result['build_path']), 18);
 
@@ -59,10 +60,9 @@ class DotcakeTestCase extends CakeTestCase {
 	}
 
 /**
- * test_RelativePath
+ * testRelativePath
  * jpn: '/'からはじまらないパスはそのまま相対パスとして処理する
  *
- * @param
  */
 	public function testRelativePath() {
 		App::build(array(
@@ -74,7 +74,7 @@ class DotcakeTestCase extends CakeTestCase {
 	}
 
 /**
- * test_PathPriority
+ * testPathPriority
  * jpn: App::build()で後から追加されたパスが優先される
  *
  */
@@ -91,5 +91,16 @@ class DotcakeTestCase extends CakeTestCase {
 		$this->assertEqual($result['build_path']['plugins'][1], 'first/path/to/plugins/');
 		$this->assertEqual($result['build_path']['plugins'][2], 'second/path/to/plugins/');
 		$this->assertEqual($result['build_path']['plugins'][3], './Plugin/');
+	}
+
+/**
+ * testCakeVersion
+ * jpn: cake_versionが.cakeに設定される
+ *
+ */
+	public function testCakeVersion(){
+		$this->Dotcake = new Dotcake();
+		$result = $this->Dotcake->generate();
+		$this->assertEqual($result['cake_version'], Configure::version());
 	}
 }

--- a/Test/Case/Lib/FormatterTest.php
+++ b/Test/Case/Lib/FormatterTest.php
@@ -32,11 +32,12 @@ class FormatterTestCase extends CakeTestCase {
 	public function testReformat() {
 		$this->Formatter = new Formatter();
 		$text = <<< EOD
-{"cake":"..\/lib\/","build_path":{"models":[".\/Model\/"],"behaviors":[".\/Model\/Behavior\/",".\/MyModel\/Behavior\/"]}}
+{"cake_version":"2.5.5","cake":"..\/lib\/","build_path":{"models":[".\/Model\/"],"behaviors":[".\/Model\/Behavior\/",".\/MyModel\/Behavior\/"]}}
 EOD;
 		$result = $this->Formatter->reformat($text);
 		$expected = <<< EOD
 {
+	"cake_version":"2.5.5",
 	"cake":"..\/lib\/",
 	"build_path":{
 		"models":[
@@ -59,11 +60,12 @@ EOD;
 	public function testReformatWithWhitespace() {
 		$this->Formatter = new Formatter("    ");
 		$text = <<< EOD
-{"cake":"..\/lib\/","build_path":{"models":[".\/Model\/"],"behaviors":[".\/Model\/Behavior\/",".\/MyModel\/Behavior\/"]}}
+{"cake_version":"2.5.5","cake":"..\/lib\/","build_path":{"models":[".\/Model\/"],"behaviors":[".\/Model\/Behavior\/",".\/MyModel\/Behavior\/"]}}
 EOD;
 		$result = $this->Formatter->reformat($text);
 		$expected = <<< EOD
 {
+    "cake_version":"2.5.5",
     "cake":"..\/lib\/",
     "build_path":{
         "models":[


### PR DESCRIPTION
cake.elは CakePHP2になった時点で cake2.el を作成し別対応しましたが、cake.vimなどはそのまま1.3と2.xに対応しているかと思います。

そういった場合に対応できるように、一応規格として `cake_version` を .cake に組み込んでおくことを提案します。
